### PR TITLE
Actualización de dependencias y versiones

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.diamon.curso"
         minSdk 23
         targetSdk 36
-        versionCode 48
-        versionName "1.5.6"
+        versionCode 49
+        versionName "1.5.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-agp = "8.11.0"
+agp = "8.13.0"
 appCenterSdkVersion = "5.0.6"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
 appcompat = "1.7.1"
-material = "1.12.0"
-activity = "1.10.1"
+material = "1.13.0"
+activity = "1.11.0"
 constraintlayout = "2.2.1"
-playServicesAds = "24.4.0"
+playServicesAds = "24.7.0"
 
 [libraries]
 appcenter-analytics = { module = "com.microsoft.appcenter:appcenter-analytics", version.ref = "appCenterSdkVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jun 08 09:32:52 VET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Se actualizó la versión de Gradle a 8.14.3.

Las versiones de las siguientes dependencias fueron actualizadas:
- AGP de 8.11.0 a 8.13.0
- JUnit de 1.2.1 a 1.3.0
- Espresso Core de 3.6.1 a 3.7.0
- Material de 1.12.0 a 1.13.0
- Activity de 1.10.1 a 1.11.0
- Play Services Ads de 24.4.0 a 24.7.0

Además, la versión de la aplicación se incrementó de 1.5.6 a 1.5.7 y el `versionCode` de 48 a 49.