### PR TITLE
USB enumeration UI, runtime soname linking, pci.ids handling, and docs updates

### DIFF
--- a/AUDITORIA_ANDROID_RUNTIME.md
+++ b/AUDITORIA_ANDROID_RUNTIME.md
@@ -22,13 +22,23 @@
 - lspci -> liblspci.so: OK
 - ftdi_eeprom -> libftdi_eeprom.so: OK
 
-## Dependencias reportadas faltantes en jniLibs
+## Dependencias críticas en jniLibs
 
-- libconfuse.so: FALTA
-- libc++_shared.so: FALTA
-- libz.so.1: FALTA
+- libconfuse.so: OK
+- libc++_shared.so: OK
+- libz_1.so (soname runtime: libz.so.1): OK
+- libcrypto_3.so (soname runtime: libcrypto.so.3): OK
+- libssl_3.so (soname runtime: libssl.so.3): OK
 
 ## Parche libusb
 
 - ANDROID_USB_FD en get_device_list: OK
 - libusb_wrap_sys_device en libusb_open: OK
+
+
+## Flujo USB en Java/UI
+
+- Enumeración USB con `UsbManager.getDeviceList()`: OK
+- Selector de dispositivo cuando hay múltiples USB conectados: OK
+- Configuración manual de `-p` desde menú (`Configurar programador flashrom`): OK
+- Ejecución nativa sigue usando `flashrom -p <valor_usuario>`: OK

--- a/MATRIZ_RUNTIME.md
+++ b/MATRIZ_RUNTIME.md
@@ -275,7 +275,7 @@ Esta matriz documenta **qué archivo base existe en `data/.../usr`**, si viene e
 | share/libftdi/examples/complete.py | SI | SI | - | NO | Copiado desde assets al primer arranque |
 | share/libftdi/examples/simple.py | SI | SI | - | NO | Copiado desde assets al primer arranque |
 | share/man/man8/flashrom.8 | SI | SI | - | NO | Copiado desde assets al primer arranque |
-| share/pci.ids.gz | SI | SI | - | NO | Copiado desde assets al primer arranque |
-| lib/libz.so.1 | NO (no viene en data base) | NO | libz.so.1 | NO | Opcional: auto-link si se agrega en jniLibs |
-| lib/libconfuse.so | NO (no viene en data base) | NO | libconfuse.so | NO | Opcional: auto-link si se agrega en jniLibs |
-| lib/libc++_shared.so | NO (no viene en data base) | NO | libc++_shared.so | NO | Opcional: auto-link si se agrega en jniLibs |
+| share/pci.ids.gz | SI | SI | - | NO | Copiado desde assets al primer arranque; si Android lo lista como `pci.ids`, se normaliza a `pci.ids.gz` en runtime |
+| lib/libz.so.1 | NO (no viene en data base) | SI | libz_1.so | SI | Enlace runtime a soname `libz.so.1` desde binario Android-compat (`libz_1.so`) |
+| lib/libconfuse.so | NO (no viene en data base) | SI | libconfuse.so | SI | Enlace runtime directo desde jniLibs |
+| lib/libc++_shared.so | NO (no viene en data base) | SI | libc++_shared.so | SI | Enlace runtime directo desde jniLibs |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Este proyecto empaqueta una cadena nativa completa (flashrom + dependencias) den
 
 ### Capa Java (Android)
 
-- Descubre dispositivos con `usb-serial-for-android` (`UsbSerialProber`).
-- Abre el dispositivo con `UsbManager.openDevice(...)`.
+- Enumera dispositivos USB con `UsbManager.getDeviceList()`.
+- Si hay múltiples dispositivos, muestra selector de dispositivo en UI (VID:PID + fabricante/producto).
+- Abre el dispositivo elegido con `UsbManager.openDevice(...)`.
 - Obtiene `fd = connection.getFileDescriptor()`.
 - Inyecta `ANDROID_USB_FD` al proceso nativo (`ProcessBuilder`), para que `libusb` parcheada lo use.
 
@@ -88,15 +89,15 @@ El código copia assets de datos (share/include/pkgconfig, etc.) al runtime y cr
 - `libcrypto.so.3`
 - `libssl.so.3`
 
-### Dependencias opcionales que quedan auto-listas
+### Resolución de nombres para Android (copia garantizada)
 
-Si agregas estas librerías a `app/src/main/jniLibs/arm64-v8a/`, el runtime las enlaza automáticamente en el siguiente arranque:
+Android solo garantiza la copia directa de nombres terminados en `.so`. Por eso el proyecto mantiene binarios renombrados en `jniLibs` y crea enlaces runtime con el soname esperado:
 
-- `libz.so.1`
-- `libconfuse.so`
-- `libc++_shared.so`
+- `libcrypto.so.3` runtime -> `libcrypto_3.so` en `jniLibs`
+- `libssl.so.3` runtime -> `libssl_3.so` en `jniLibs`
+- `libz.so.1` runtime -> `libz_1.so` en `jniLibs`
 
-Si no están, se informa en log como faltantes.
+Las variantes con versión original (`*.so.N`) se pueden conservar como respaldo, pero el flujo principal usa los nombres Android-compatibles.
 
 ---
 
@@ -119,14 +120,17 @@ Con esto, flashrom/libusb usan el descriptor otorgado por Android en Java, evita
 
 ## 6) Detección de dispositivos y soporte
 
-La app está orientada a trabajar con el ecosistema soportado por flashrom (programadores/chips según build y drivers disponibles), incluyendo flujos SPI/I2C cuando el hardware/driver de flashrom lo soporte; usa `usb-serial-for-android` para facilitar descubrimiento/permisos USB.
+La app está orientada a trabajar con el ecosistema soportado por flashrom (programadores/chips según build y drivers disponibles), incluyendo flujos SPI/I2C cuando el hardware/driver de flashrom lo soporte.
+
+La detección USB en Java usa la API nativa de Android (`UsbManager`) y permite elegir dispositivo cuando hay más de uno conectado. Además, desde el menú se puede cambiar el valor de programador `-p` para cualquier backend soportado por flashrom.
 
 Flujo recomendado:
 
-1. Prober Java encuentra dispositivo USB.
-2. Android concede permiso y se obtiene FD.
-3. Se exporta `ANDROID_USB_FD` al proceso nativo.
-4. flashrom opera con libusb parcheada.
+1. Java enumera dispositivos USB con `UsbManager`.
+2. Si hay varios, el usuario selecciona cuál usar.
+3. Android concede permiso y se obtiene FD.
+4. Se exporta `ANDROID_USB_FD` al proceso nativo.
+5. flashrom opera con libusb parcheada.
 
 ---
 
@@ -151,7 +155,7 @@ bash ./setup-sdk.sh
 ## 8) Uso básico de la app
 
 1. Conecta el programador USB OTG.
-2. Pulsa **Conectar Programador** y concede permiso.
+2. Pulsa **Conectar Programador**, elige dispositivo si aparece el selector, y concede permiso.
 3. Usa:
    - **Probar Conexión** (`flashrom -p <programador>`)
    - **Leer EEPROM** (`-r bios.bin`)
@@ -185,8 +189,6 @@ El panel de log muestra salida nativa real con prefijo `[native]` y estados de e
   https://gitlab.zapb.de/libjaylink/libjaylink
 - **OpenSSL (`libcrypto`/`libssl`)** — Apache License 2.0  
   https://www.openssl.org/
-- **usb-serial-for-android** — MIT  
-  https://github.com/mik3y/usb-serial-for-android
 
 > Revisa siempre obligaciones de distribución de binarios y código fuente según cada licencia.
 
@@ -195,7 +197,8 @@ El panel de log muestra salida nativa real con prefijo `[native]` y estados de e
 ## 10) Notas operativas importantes
 
 - La app y los binarios están preparados para **ARM64 (`arm64-v8a`)**.
-- Para evitar conflictos, Java se usa para prober/permisos/FD, y la operación del bus USB la realiza la capa nativa (flashrom/libusb parcheada).
+- Java usa `UsbManager` nativo para enumeración/selección/permisos/FD, y la operación del bus USB la realiza la capa nativa (flashrom/libusb parcheada).
+- La selección de backend de flashrom (`-p`) se configura en la app y puede adaptarse a distintos programadores soportados por flashrom.
 - Si agregas nuevos binarios/librerías en `jniLibs`, respeta sonames y rutas runtime esperadas para mantener compatibilidad.
 
 ---

--- a/REPORTE_DEPENDENCIAS_BINARIOS.md
+++ b/REPORTE_DEPENDENCIAS_BINARIOS.md
@@ -5,10 +5,10 @@ Este reporte de `DT_NEEDED` se complementa con:
 - `MATRIZ_RUNTIME.mdo` (mapeo archivo por archivo a estrategia runtime)
 - `AUDITORIA_ANDROID_RUNTIME.md` (checklist operativo)
 
-## Resumen de dependencias críticas y opcionales
+## Resumen de dependencias críticas
 
-- Dependencias base presentes en `jniLibs` para flashrom y librerías principales: `libusb-1.0.so`, `libpci.so(.3/.3.14.0)`, `libftdi1.so(.2/.2.6.0)`, `libftdipp1.so(.3/.2.6.0)`, `libjaylink.so`, `libcrypto.so.3`, `libssl.so.3`, `libflashrom.so(.1/.1.0.0)`, `libflashrom_bin.so`, `libsetpci.so`, `libpcilmr.so`, `liblspci.so`, `libupdate-pciids.so`, `libftdi_eeprom.so`, `liblibftdi1-config.so`, `libpyftdi1.so`.
-- Dependencias opcionales reportadas por `DT_NEEDED` de algunos binarios que pueden no venir en el paquete inicial y se contemplan para auto-link cuando se agreguen en `jniLibs`: `libz.so.1`, `libconfuse.so`, `libc++_shared.so`.
+- Dependencias base presentes en `jniLibs` para flashrom y librerías principales: `libusb-1.0.so`, `libpci.so(.3/.3.14.0)`, `libftdi1.so(.2/.2.6.0)`, `libftdipp1.so(.3/.2.6.0)`, `libjaylink.so`, `libflashrom.so(.1/.1.0.0)`, `libflashrom_bin.so`, `libsetpci.so`, `libpcilmr.so`, `liblspci.so`, `libupdate-pciids.so`, `libftdi_eeprom.so`, `liblibftdi1-config.so`, `libpyftdi1.so`, `libconfuse.so`, `libc++_shared.so`.
+- Sonames versionados que en Android se resuelven usando binarios renombrados terminados en `.so`: `libcrypto.so.3` -> `libcrypto_3.so`, `libssl.so.3` -> `libssl_3.so`, `libz.so.1` -> `libz_1.so`.
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,6 @@ dependencies {
     implementation libs.appcompat
     implementation libs.material
     implementation libs.constraintlayout
-    implementation(libs.usb.serial.for1.android)
     implementation libs.documentfile
     testImplementation libs.junit
     androidTestImplementation libs.ext.junit

--- a/app/src/main/java/com/diamon/curso/AssetHelper.java
+++ b/app/src/main/java/com/diamon/curso/AssetHelper.java
@@ -11,7 +11,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class AssetHelper {
     private static final String TAG = "AssetHelper";
@@ -42,20 +44,10 @@ public class AssetHelper {
         }
 
         // Reparación mínima de recursos críticos del runtime compilado (no ejecutables).
-        String[] criticalAssets = new String[] {
-                runtimeRoot + "/share/pci.ids.gz"
-        };
-
         AssetManager assetManager = context.getAssets();
-        for (String criticalAsset : criticalAssets) {
-            String relative = criticalAsset.substring((runtimeRoot + "/").length());
-            File target = new File(usrDir, relative);
-            if (!target.exists()) {
-                File parent = target.getParentFile();
-                if (parent == null || !copyAssetFile(assetManager, criticalAsset, parent)) {
-                    return false;
-                }
-            }
+        File pciIdsTarget = new File(usrDir, "share/pci.ids.gz");
+        if (!pciIdsTarget.exists() && !copyCriticalPciIds(assetManager, runtimeRoot, pciIdsTarget)) {
+            return false;
         }
         return ensureNativeToolLinks(context);
     }
@@ -159,6 +151,11 @@ public class AssetHelper {
 
     private static boolean copyAssetFile(AssetManager assetManager, String assetPath, File destDir) {
         String fileName = assetPath.substring(assetPath.lastIndexOf('/') + 1);
+        if (assetPath.endsWith("/share/pci.ids")) {
+            // En algunos empaquetados Android, pci.ids.gz puede quedar listado como pci.ids.
+            // Conservamos el nombre runtime esperado por pciutils/flashrom.
+            fileName = "pci.ids.gz";
+        }
         File destFile = new File(destDir, fileName);
 
         // Si el archivo ya existe, omitir
@@ -203,6 +200,30 @@ public class AssetHelper {
         return shareDir.exists() && shareDir.isDirectory() && shareDir.list() != null && shareDir.list().length > 0;
     }
 
+    private static boolean copyCriticalPciIds(AssetManager assetManager, String runtimeRoot, File target) {
+        String[] candidates = new String[] {
+                runtimeRoot + "/share/pci.ids.gz",
+                runtimeRoot + "/share/pci.ids"
+        };
+
+        File parent = target.getParentFile();
+        if (parent == null) {
+            return false;
+        }
+
+        for (String candidate : candidates) {
+            try (InputStream ignored = assetManager.open(candidate)) {
+                Log.i(TAG, "Copiando pci.ids crítico desde asset: " + candidate);
+                return copyAssetFile(assetManager, candidate, parent);
+            } catch (IOException ignored) {
+                // Intentar siguiente candidato
+            }
+        }
+
+        Log.e(TAG, "No se encontró pci.ids(.gz) en assets para reconstruir runtime crítico.");
+        return false;
+    }
+
     private static boolean ensureNativeToolLinks(Context context) {
         File filesDir = context.getFilesDir();
         File nativeLibDir = new File(context.getApplicationInfo().nativeLibraryDir);
@@ -226,59 +247,75 @@ public class AssetHelper {
         ok &= linkTool(new File(usrBin, "ftdi_eeprom"), new File(nativeLibDir, "libftdi_eeprom.so"));
         ok &= linkTool(new File(usrBin, "libftdi1-config"), new File(nativeLibDir, "liblibftdi1-config.so"));
 
-        // Sonames esperados por binarios/nativas: apuntan a jniLibs cuando aplica (ruta exacta runtime).
-        linkTool(new File(usrLib, "libflashrom.so"), new File(nativeLibDir, "libflashrom.so"));
-        linkTool(new File(usrLib, "libflashrom.so.1"), new File(nativeLibDir, "libflashrom.so.1"));
-        linkTool(new File(usrLib, "libflashrom.so.1.0.0"), new File(nativeLibDir, "libflashrom.so.1.0.0"));
+        // Sonames esperados por binarios/nativas: apuntan al nombre Android copiable (.so).
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libflashrom.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libflashrom.so.1");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libflashrom.so.1.0.0");
 
-        linkTool(new File(usrLib, "libpci.so"), new File(nativeLibDir, "libpci.so"));
-        linkTool(new File(usrLib, "libpci.so.3"), new File(nativeLibDir, "libpci.so.3"));
-        linkTool(new File(usrLib, "libpci.so.3.14.0"), new File(nativeLibDir, "libpci.so.3.14.0"));
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libpci.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libpci.so.3");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libpci.so.3.14.0");
 
-        linkTool(new File(usrLib, "libftdi1.so"), new File(nativeLibDir, "libftdi1.so"));
-        linkTool(new File(usrLib, "libftdi1.so.2"), new File(nativeLibDir, "libftdi1.so.2"));
-        linkTool(new File(usrLib, "libftdi1.so.2.6.0"), new File(nativeLibDir, "libftdi1.so.2.6.0"));
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdi1.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdi1.so.2");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdi1.so.2.6.0");
 
-        linkTool(new File(usrLib, "libftdipp1.so"), new File(nativeLibDir, "libftdipp1.so"));
-        linkTool(new File(usrLib, "libftdipp1.so.3"), new File(nativeLibDir, "libftdipp1.so.3"));
-        linkTool(new File(usrLib, "libftdipp1.so.2.6.0"), new File(nativeLibDir, "libftdipp1.so.2.6.0"));
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdipp1.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdipp1.so.3");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libftdipp1.so.2.6.0");
 
-        linkTool(new File(usrLib, "libusb-1.0.so"), new File(nativeLibDir, "libusb-1.0.so"));
-        linkTool(new File(usrLib, "libjaylink.so"), new File(nativeLibDir, "libjaylink.so"));
-        linkTool(new File(usrLib, "libcrypto.so.3"), new File(nativeLibDir, "libcrypto.so.3"));
-        linkTool(new File(usrLib, "libssl.so.3"), new File(nativeLibDir, "libssl.so.3"));
-        ensureOptionalRuntimeLink(usrLib, nativeLibDir, "libz.so.1");
-        ensureOptionalRuntimeLink(usrLib, nativeLibDir, "libconfuse.so");
-        ensureOptionalRuntimeLink(usrLib, nativeLibDir, "libc++_shared.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libusb-1.0.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libjaylink.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libcrypto.so.3");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libssl.so.3");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libz.so.1");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libconfuse.so");
+        ok &= linkRuntimeSoname(usrLib, nativeLibDir, "libc++_shared.so");
         // Extensión Python: nombre Android en jniLibs y nombre original vía symlink en site-packages.
         linkTool(new File(pythonSitePackages, "_pyftdi1.so"), new File(nativeLibDir, "libpyftdi1.so"));
 
         // Validación mínima de dependencias críticas para herramientas principales.
         ok &= ensurePresent(new File(usrLib, "libcrypto.so.3"));
         ok &= ensurePresent(new File(usrLib, "libssl.so.3"));
-        ensureOptionalPresent(new File(usrLib, "libconfuse.so"), "ftdi_eeprom");
-        ensureOptionalPresent(new File(usrLib, "libz.so.1"), "pciutils (lspci/setpci/pcilmr)");
-        ensureOptionalPresent(new File(usrLib, "libc++_shared.so"), "libftdipp1");
+        ok &= ensurePresent(new File(usrLib, "libconfuse.so"));
+        ok &= ensurePresent(new File(usrLib, "libz.so.1"));
+        ok &= ensurePresent(new File(usrLib, "libc++_shared.so"));
 
         return ok;
     }
 
-    private static void ensureOptionalRuntimeLink(File usrLib, File nativeLibDir, String soname) {
-        File runtimeTarget = new File(usrLib, soname);
-        if (runtimeTarget.exists()) {
-            return;
+    private static boolean linkRuntimeSoname(File usrLib, File nativeLibDir, String runtimeSoname) {
+        File linkPath = new File(usrLib, runtimeSoname);
+        File source = resolveNativeLibrary(nativeLibDir, runtimeSoname);
+        if (source == null) {
+            Log.w(TAG, "No se encontró librería para soname runtime: " + runtimeSoname);
+            return false;
+        }
+        return linkTool(linkPath, source);
+    }
+
+    private static File resolveNativeLibrary(File nativeLibDir, String runtimeSoname) {
+        for (String candidate : getNativeCandidates(runtimeSoname)) {
+            File file = new File(nativeLibDir, candidate);
+            if (file.exists()) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> getNativeCandidates(String runtimeSoname) {
+        Set<String> candidates = new LinkedHashSet<>();
+        candidates.add(runtimeSoname);
+
+        int soMarker = runtimeSoname.indexOf(".so.");
+        if (soMarker > 0) {
+            String base = runtimeSoname.substring(0, soMarker);
+            String suffix = runtimeSoname.substring(soMarker + 4).replace('.', '_');
+            candidates.add(base + "_" + suffix + ".so");
         }
 
-        File jniTarget = new File(nativeLibDir, soname);
-        if (!jniTarget.exists()) {
-            Log.w(TAG, "Dependencia opcional aún no disponible en jniLibs: " + soname +
-                    ". Se enlazará automáticamente cuando sea agregada.");
-            return;
-        }
-
-        if (linkTool(runtimeTarget, jniTarget)) {
-            Log.i(TAG, "Dependencia opcional enlazada automáticamente: " + soname);
-        }
+        return new ArrayList<>(candidates);
     }
 
     private static boolean ensurePresent(File file) {
@@ -287,12 +324,6 @@ public class AssetHelper {
             return false;
         }
         return true;
-    }
-
-    private static void ensureOptionalPresent(File file, String consumer) {
-        if (!file.exists()) {
-            Log.w(TAG, "Dependencia opcional ausente " + file.getName() + " (consumidor: " + consumer + ")");
-        }
     }
 
     private static boolean linkTool(File linkPath, File target) {

--- a/app/src/main/java/com/diamon/curso/MainActivity.java
+++ b/app/src/main/java/com/diamon/curso/MainActivity.java
@@ -30,9 +30,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.hoho.android.usbserial.driver.UsbSerialDriver;
-import com.hoho.android.usbserial.driver.UsbSerialProber;
+import androidx.core.content.ContextCompat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -184,11 +182,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Setup Boradcast Receiver
         IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            registerReceiver(usbReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
-        } else {
-            registerReceiver(usbReceiver, filter);
-        }
+        ContextCompat.registerReceiver(this, usbReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 
         // Listener setup para todos los botones
         btnConnect.setOnClickListener(v -> searchAndRequestProgrammer());
@@ -254,14 +248,31 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void searchAndRequestProgrammer() {
-        List<UsbSerialDriver> availableDrivers = UsbSerialProber.getDefaultProber().findAllDrivers(usbManager);
-        if (availableDrivers.isEmpty()) {
-            log("No se detectó ningún programador USB compatible conectado.");
+        Map<String, UsbDevice> devices = usbManager.getDeviceList();
+        if (devices == null || devices.isEmpty()) {
+            log("No se detectó ningún dispositivo USB conectado.");
             return;
         }
 
-        UsbSerialDriver driver = availableDrivers.get(0);
-        UsbDevice device = driver.getDevice();
+        List<UsbDevice> candidates = new ArrayList<>(devices.values());
+        if (candidates.size() == 1) {
+            requestUsbPermission(candidates.get(0));
+            return;
+        }
+
+        CharSequence[] labels = new CharSequence[candidates.size()];
+        for (int i = 0; i < candidates.size(); i++) {
+            labels[i] = formatUsbDeviceLabel(candidates.get(i));
+        }
+
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Selecciona dispositivo USB")
+                .setItems(labels, (dialog, which) -> requestUsbPermission(candidates.get(which)))
+                .setNegativeButton("Cancelar", null)
+                .show();
+    }
+
+    private void requestUsbPermission(UsbDevice device) {
         log("Dispositivo detectado: " + device.getProductName() + " | Solicitando enlace...");
         log("VID:PID detectado => " + String.format(Locale.US, "%04x:%04x", device.getVendorId(), device.getProductId()));
 
@@ -273,6 +284,19 @@ public class MainActivity extends AppCompatActivity {
                     flags);
             usbManager.requestPermission(device, permissionIntent);
         }
+    }
+
+    private String formatUsbDeviceLabel(UsbDevice device) {
+        String productName = device.getProductName();
+        if (productName == null || productName.trim().isEmpty()) {
+            productName = "Dispositivo USB";
+        }
+        String manufacturer = device.getManufacturerName();
+        if (manufacturer == null || manufacturer.trim().isEmpty()) {
+            manufacturer = "Fabricante desconocido";
+        }
+        return productName + " (" + manufacturer + ")\nVID:PID "
+                + String.format(Locale.US, "%04x:%04x", device.getVendorId(), device.getProductId());
     }
 
     private void connectToDevice(UsbDevice device) {
@@ -470,8 +494,12 @@ public class MainActivity extends AppCompatActivity {
         log("Ruta usr/lib runtime: " + usrLibDir.getAbsolutePath());
         log("Ruta usr/share runtime: " + usrShareDir.getAbsolutePath());
         log("libflashrom_bin.so presente: " + new File(nativeDir, "libflashrom_bin.so").exists());
-        log("libcrypto.so.3 en runtime: " + new File(usrLibDir, "libcrypto.so.3").exists());
-        log("libssl.so.3 en runtime: " + new File(usrLibDir, "libssl.so.3").exists());
+        log("libcrypto.so.3 en runtime: " + new File(usrLibDir, "libcrypto.so.3").exists()
+                + " (jni origen: " + findNativeName(nativeDir, "libcrypto.so.3") + ")");
+        log("libssl.so.3 en runtime: " + new File(usrLibDir, "libssl.so.3").exists()
+                + " (jni origen: " + findNativeName(nativeDir, "libssl.so.3") + ")");
+        log("libz.so.1 en runtime: " + new File(usrLibDir, "libz.so.1").exists()
+                + " (jni origen: " + findNativeName(nativeDir, "libz.so.1") + ")");
         log("pci.ids.gz en runtime: " + new File(usrShareDir, "pci.ids.gz").exists());
     }
 
@@ -481,16 +509,28 @@ public class MainActivity extends AppCompatActivity {
         for (String name : requiredBins) {
             log("jniLibs binario " + name + ": " + new File(nativeDir, name).exists());
         }
-        String[] requiredLibs = {"libusb-1.0.so", "libflashrom.so", "libpci.so", "libftdi1.so", "libjaylink.so", "libcrypto.so.3", "libssl.so.3"};
+        String[] requiredLibs = {"libusb-1.0.so", "libflashrom.so", "libpci.so", "libftdi1.so", "libjaylink.so", "libcrypto.so.3", "libssl.so.3", "libz.so.1", "libconfuse.so", "libc++_shared.so"};
         for (String name : requiredLibs) {
-            log("jniLibs librería " + name + ": " + new File(nativeDir, name).exists());
+            String nativeName = findNativeName(nativeDir, name);
+            log("jniLibs librería " + name + ": " + !"NO".equals(nativeName)
+                    + " (archivo: " + nativeName + ")");
         }
-        String[] optionalMissing = {"libconfuse.so", "libc++_shared.so", "libz.so.1"};
-        for (String name : optionalMissing) {
-            boolean present = new File(nativeDir, name).exists();
-            log("jniLibs dependencia reportada " + name + ": " + present
-                    + (present ? "" : " (faltante, se enlazará automáticamente al agregarla)"));
+    }
+
+    private String findNativeName(File nativeDir, String runtimeSoname) {
+        File exact = new File(nativeDir, runtimeSoname);
+        if (exact.exists()) {
+            return runtimeSoname;
         }
+        int marker = runtimeSoname.indexOf(".so.");
+        if (marker > 0) {
+            String altName = runtimeSoname.substring(0, marker) + "_"
+                    + runtimeSoname.substring(marker + 4).replace('.', '_') + ".so";
+            if (new File(nativeDir, altName).exists()) {
+                return altName;
+            }
+        }
+        return "NO";
     }
 
     // Función de soporte para limpiar directorios defectuosos guardados por el
@@ -530,6 +570,9 @@ public class MainActivity extends AppCompatActivity {
         if (id == R.id.action_hex_viewer) {
             startActivity(new Intent(this, HexViewerActivity.class));
             return true;
+        } else if (id == R.id.action_programmer) {
+            showProgrammerDialog(null);
+            return true;
         } else if (id == R.id.action_clear_logs) {
             tvLog.setText("--- Log ---");
             log("Terminal reiniciada.");
@@ -553,19 +596,22 @@ public class MainActivity extends AppCompatActivity {
         aboutText.setTextColor(getResources().getColor(android.R.color.black, getTheme()));
         aboutText.setLinkTextColor(getResources().getColor(android.R.color.holo_blue_dark, getTheme()));
         aboutText.setMovementMethod(LinkMovementMethod.getInstance());
-        aboutText.setText(Html.fromHtml(
-                "<b>Quemador EEPROM</b><br/>"
-                        + "Proyecto Android para lectura/escritura SPI con flashrom en NDK.<br/><br/>"
-                        + "<b>Licencia del proyecto:</b> GPLv3 (LICENSE.txt).<br/><br/>"
-                        + "<b>Dependencias principales y licencias:</b><br/>"
-                        + "• <a href='https://github.com/libusb/libusb'>libusb</a> (LGPL-2.1+)<br/>"
-                        + "• <a href='https://github.com/pciutils/pciutils'>pciutils</a> (GPL-2.0+)<br/>"
-                        + "• <a href='https://developer.intra2net.com/git/libftdi'>libftdi</a> (LGPL-2.1+)<br/>"
-                        + "• <a href='https://gitlab.zapb.de/libjaylink/libjaylink'>libjaylink</a> (GPL-2.0+)<br/>"
-                        + "• <a href='https://github.com/flashrom/flashrom'>flashrom</a> (GPL-2.0+)<br/>"
-                        + "• <a href='https://github.com/mik3y/usb-serial-for-android'>usb-serial-for-android</a> (MIT)<br/><br/>"
-                        + "Compilación y rutas basadas en linesCorrectos.txt y assets/data.",
-                Html.FROM_HTML_MODE_LEGACY));
+        String aboutHtml = "<b>Flash EEPROM Tool</b><br/>"
+                + "Aplicación Android para lectura, verificación y escritura SPI/I2C con flashrom.<br/><br/>"
+                + "<b>Licencia del proyecto:</b> GPLv3.<br/><br/>"
+                + "<b>Dependencias principales y licencias:</b><br/>"
+                + "• <a href='https://github.com/libusb/libusb'>libusb</a> (LGPL-2.1+)<br/>"
+                + "• <a href='https://github.com/pciutils/pciutils'>pciutils</a> (GPL-2.0+)<br/>"
+                + "• <a href='https://developer.intra2net.com/git/libftdi'>libftdi</a> (LGPL-2.1+)<br/>"
+                + "• <a href='https://gitlab.zapb.de/libjaylink/libjaylink'>libjaylink</a> (GPL-2.0+)<br/>"
+                + "• <a href='https://github.com/flashrom/flashrom'>flashrom</a> (GPL-2.0+)";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            aboutText.setText(Html.fromHtml(aboutHtml, Html.FROM_HTML_MODE_LEGACY));
+        } else {
+            @SuppressWarnings("deprecation")
+            android.text.Spanned legacyHtml = Html.fromHtml(aboutHtml);
+            aboutText.setText(legacyHtml);
+        }
 
         new android.app.AlertDialog.Builder(this)
                 .setTitle("Acerca de")

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -8,6 +8,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_programmer"
+        android:title="Configurar programador flashrom"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_clear_logs"
         android:title="Limpiar logs"
         app:showAsAction="never" />


### PR DESCRIPTION
### Motivation

- Garantizar que las bibliotecas nativas versionadas se resuelvan correctamente en Android usando nombres copiados/renombrados en `jniLibs` y enlaces runtime equivalentes.
- Soportar enumeración/selección de dispositivos USB con la API nativa de Android en vez de depender de `usb-serial-for-android`. 
- Asegurar la presencia y normalización de `pci.ids.gz` en assets/runtime incluso cuando Android lo liste como `pci.ids`.
- Actualizar la documentación y matrices para reflejar la estrategia de nombres Android-compatibles y el flujo USB en la UI.

### Description

- `AssetHelper`: añade detección/copia robusta para `pci.ids.gz` (acepta `pci.ids` en assets), renombra/copias archivos según runtime esperado, refactoriza el enlace de sonames con `linkRuntimeSoname`, `resolveNativeLibrary` y `getNativeCandidates` para soportar variantes Android (`libz_1.so`, `libcrypto_3.so`, `libssl_3.so`) y mantiene fallback por copia si `symlink` falla.  
- `MainActivity`: elimina la dependencia en `usb-serial-for-android` y pasa a usar `UsbManager.getDeviceList()` con selector de dispositivo cuando hay múltiples, añade `requestUsbPermission(UsbDevice)`, `formatUsbDeviceLabel(...)`, cambia el registro del `BroadcastReceiver` a `ContextCompat.registerReceiver(...)`, mejora logs de dependencias nativas con `findNativeName(...)`, y añade entrada de menú para configurar el programador y ajustar el diálogo "Acerca de" para compatibilidad de API.
- `app/build.gradle`: quita la dependencia `usb-serial-for-android` (comentada/eliminada) y mantiene packaging/strip settings.
- Recursos: agrega item de menú `action_programmer` en `res/menu/main_menu.xml`.
- Documentación: actualiza `README.md`, `AUDITORIA_ANDROID_RUNTIME.md`, `MATRIZ_RUNTIME.md` y `REPORTE_DEPENDENCIAS_BINARIOS.md` para reflejar la estrategia de nombres Android-compatibles, la resolución de sonames renombrados y el flujo USB en Java/UI.

### Testing

- Construido el paquete de Android con `./gradlew assembleDebug` y la build finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d45f6e288330bf09aa4ee9c162bd)