### PR TITLE
Add programmer selector, manual command UI and runtime/docs (privacy, store description, integration guide)

### DIFF
--- a/AUDITORIA_ANDROID_RUNTIME.md
+++ b/AUDITORIA_ANDROID_RUNTIME.md
@@ -35,10 +35,20 @@
 - ANDROID_USB_FD en get_device_list: OK
 - libusb_wrap_sys_device en libusb_open: OK
 
-
 ## Flujo USB en Java/UI
 
 - Enumeración USB con `UsbManager.getDeviceList()`: OK
 - Selector de dispositivo cuando hay múltiples USB conectados: OK
-- Configuración manual de `-p` desde menú (`Configurar programador flashrom`): OK
+- Menú **Agregar dispositivo/programador flashrom (lista)** con programadores soportados: OK
+- Menú **Configurar programador manual (anterior)** (texto libre legacy): OK
+- Campo de comando manual para ejecutar parámetros flashrom y ver salida en consola: OK
+- Comandos manuales sin USB conectado (ej. `--version`, `-L`, `--help`): OK
 - Ejecución nativa sigue usando `flashrom -p <valor_usuario>`: OK
+
+## Programadores soportados por esta build (según logs)
+
+asm106x, atavia, buspirate_spi, ch341a_spi, ch347_spi, dediprog, developerbox_spi, digilent_spi, dirtyjtag_spi, drkaiser, dummy, ft2232_spi, gfxnvidia, internal, it8212, jlink_spi, linux_mtd, linux_spi, parade_lspcon, mediatek_i2c_spi, mstarddc_spi, nicintel, nicintel_eeprom, nicintel_spi, nv_sma_spi, ogp_spi, pickit2_spi, pony_spi, raiden_debug_spi, realtek_mst_i2c_spi, satasii, serprog, spidriver, stlinkv3_spi, usbblaster_spi.
+
+## Programadores no soportados en esta plataforma
+
+atahpt, atapromise, ni845x_spi, nic3com, nicnatsemi, nicrealtek, rayer_spi, satamv.

--- a/GOOGLE_PLAY_DESCRIPCION.md
+++ b/GOOGLE_PLAY_DESCRIPCION.md
@@ -1,0 +1,31 @@
+# Descripción para Google Play
+
+## Descripción corta
+
+Herramienta Android para detectar programadores USB y leer, verificar, respaldar o escribir memoria EEPROM/flash con flujo técnico guiado.
+
+## Descripción larga
+
+Flash EEPROM Tool te permite trabajar con chips de memoria desde Android usando un flujo práctico para laboratorio y reparación electrónica.
+
+Conecta tu programador por USB OTG, detecta el dispositivo, selecciona el modo de trabajo y ejecuta tareas de lectura, verificación, respaldo y escritura del archivo de firmware.
+
+### Qué puedes hacer
+
+- Detectar y conectar dispositivos USB compatibles.
+- Seleccionar programadores soportados por la versión integrada.
+- Identificar chip y revisar salida técnica en consola.
+- Leer y guardar respaldo (`backup`) de la memoria.
+- Importar un archivo binario para escribirlo en el chip.
+- Verificar contenido del chip contra un archivo.
+- Ejecutar comandos manuales para diagnóstico avanzado.
+
+### Dispositivos/programadores soportados por esta versión
+
+asm106x, atavia, buspirate_spi, ch341a_spi, ch347_spi, dediprog, developerbox_spi, digilent_spi, dirtyjtag_spi, drkaiser, dummy, ft2232_spi, gfxnvidia, internal, it8212, jlink_spi, linux_mtd, linux_spi, parade_lspcon, mediatek_i2c_spi, mstarddc_spi, nicintel, nicintel_eeprom, nicintel_spi, nv_sma_spi, ogp_spi, pickit2_spi, pony_spi, raiden_debug_spi, realtek_mst_i2c_spi, satasii, serprog, spidriver, stlinkv3_spi y usbblaster_spi.
+
+### No soportados en esta plataforma/build
+
+atahpt, atapromise, ni845x_spi, nic3com, nicnatsemi, nicrealtek, rayer_spi y satamv.
+
+La aplicación está enfocada en usuarios técnicos y entusiastas que necesitan una herramienta portátil para diagnóstico y mantenimiento de firmware desde el teléfono.

--- a/GUIA_INTEGRACION_BINARIOS.md
+++ b/GUIA_INTEGRACION_BINARIOS.md
@@ -1,0 +1,60 @@
+# Mini guía: integración manual de 9 binarios/archivos actualizados
+
+> Esta guía está pensada para que **tú reemplaces manualmente** los binarios nuevos sin borrar nada en este PR, evitando errores de compilación durante CI/local.
+
+## 1) Regla principal
+
+- Mantén en el repositorio los binarios actuales para compilar.
+- Integra tus 9 archivos nuevos **después** de este PR, reemplazando contenido archivo por archivo.
+- Si un archivo nuevo trae nombre distinto, **renómbralo al nombre exacto que ya usa el proyecto**.
+
+## 2) Dónde colocar cada tipo de archivo
+
+### A) Runtime raíz (carpeta `data/` del repo)
+
+Coloca/reemplaza en:
+
+- `data/data/com.diamon.curso/files/usr/lib/`
+- `data/data/com.diamon.curso/files/usr/share/bash-completion/completions/`
+- `data/data/com.diamon.curso/files/usr/share/man/man8/`
+
+### B) Assets empaquetados de Android
+
+Cada archivo que reemplaces en `data/...` también debe reflejarse en:
+
+- `app/src/main/assets/data/data/com.diamon.curso/files/usr/lib/`
+- `app/src/main/assets/data/data/com.diamon.curso/files/usr/share/bash-completion/completions/`
+- `app/src/main/assets/data/data/com.diamon.curso/files/usr/share/man/man8/`
+
+## 3) Lista sugerida según tus capturas
+
+De acuerdo con tus imágenes, los cambios incluyen (al menos):
+
+- `libflashrom.a`
+- `libflashrom.so.1.0.0`
+- `libftdi1.a`
+- `libftdi1.so.2.6.0`
+- `libjaylink.a`
+- `flashrom.bash`
+- `flashrom.8`
+
+Completa la lista exacta de 9 en tu entorno y reemplaza en ambas ubicaciones (runtime + assets).
+
+## 4) Duplicados con nombres incompatibles
+
+Si te llega una variante con nombre no compatible para Android/jni, no borres nada aquí:
+
+1. Conserva el archivo existente usado por la app.
+2. Renombra tu nuevo binario al nombre esperado por el proyecto (mismo nombre que el viejo).
+3. Reemplaza contenido en sitio.
+
+## 5) Verificación rápida recomendada
+
+Después de tu reemplazo manual:
+
+```bash
+git status --short
+./gradlew assembleDebug
+```
+
+Si compila y solo aparecen tus archivos objetivo, integración correcta.

--- a/MATRIZ_RUNTIME.md
+++ b/MATRIZ_RUNTIME.md
@@ -1,3 +1,12 @@
+
+## Estado documental actual
+
+- README actualizado con programadores soportados/no soportados según logs de build.
+- Auditoría UI actualizada con selector por lista, modo manual legacy y comando manual en UI principal.
+- Guía de integración manual de 9 binarios disponible en `GUIA_INTEGRACION_BINARIOS.md` (sin borrado de binarios en PR).
+
+---
+
 # Matriz de Runtime (data → assets/jniLibs → files/usr)
 
 Esta matriz documenta **qué archivo base existe en `data/.../usr`**, si viene en assets, si se resuelve por `jniLibs`, y la estrategia final en runtime (`/data/user/0/com.diamon.curso/files/usr`).

--- a/POLITICA_PRIVACIDAD.html
+++ b/POLITICA_PRIVACIDAD.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Política de Privacidad - Flash EEPROM Tool</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #f7f7f7; color: #1a1a1a; }
+    main { max-width: 900px; margin: 24px auto; background: #fff; padding: 24px; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,.08); }
+    h1, h2 { color: #0b5cab; }
+    code { background: #f0f0f0; padding: 2px 6px; border-radius: 4px; }
+    a { color: #0b5cab; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Política de Privacidad de Flash EEPROM Tool</h1>
+    <p><strong>Última actualización:</strong> 2026-02-28</p>
+
+    <h2>1. Responsable</h2>
+    <p>
+      <strong>Autor:</strong> Daniel Diamon<br />
+      <strong>Correo:</strong> <a href="mailto:danielpdiamon@gmail.com">danielpdiamon@gmail.com</a><br />
+      <strong>Teléfono:</strong> 0424-4259578
+    </p>
+
+    <h2>2. Datos que puede recopilar la aplicación</h2>
+    <p>La aplicación puede procesar datos técnicos de funcionamiento para diagnóstico, tales como:</p>
+    <ul>
+      <li>Información de conexión USB (por ejemplo VID/PID y estados de conexión).</li>
+      <li>Registros técnicos (logs) de ejecución de comandos.</li>
+      <li>Archivos binarios seleccionados por el usuario para lectura/escritura/verificación.</li>
+    </ul>
+
+    <p>
+      Además, el proyecto contempla integrar servicios de terceros para monetización y analítica:
+    </p>
+    <ul>
+      <li><strong>Google AdMob</strong>: para publicidad (incluyendo identificadores publicitarios cuando aplique).</li>
+      <li><strong>App Center</strong>: para analíticas de uso y estabilidad.</li>
+    </ul>
+
+    <h2>3. Permisos</h2>
+    <p>
+      La app puede requerir permisos vinculados a:
+    </p>
+    <ul>
+      <li>Acceso a dispositivos USB OTG para comunicación con programadores.</li>
+      <li>Selección y guardado de archivos mediante el sistema de documentos de Android.</li>
+      <li>Acceso a Internet para funcionalidades en línea y futuras integraciones de servicios.</li>
+    </ul>
+
+    <h2>4. Uso de la información</h2>
+    <p>La información se utiliza para:</p>
+    <ul>
+      <li>Ejecutar funciones de lectura, respaldo, verificación y escritura de firmware.</li>
+      <li>Mostrar resultados y mensajes de diagnóstico al usuario.</li>
+      <li>Mejorar estabilidad y experiencia del producto.</li>
+    </ul>
+
+    <h2>5. Repositorios base del proyecto y licencias</h2>
+    <ul>
+      <li><a href="https://github.com/flashrom/flashrom">flashrom</a> — GPL-2.0+</li>
+      <li><a href="https://github.com/libusb/libusb">libusb</a> — LGPL-2.1+</li>
+      <li><a href="https://github.com/pciutils/pciutils">pciutils</a> — GPL-2.0+</li>
+      <li><a href="https://developer.intra2net.com/git/libftdi">libftdi</a> — LGPL-2.1+</li>
+      <li><a href="https://gitlab.zapb.de/libjaylink/libjaylink">libjaylink</a> — GPL-2.0+</li>
+      <li><a href="https://github.com/mik3y/usb-serial-for-android">usb-serial-for-android</a> — MIT</li>
+    </ul>
+
+    <h2>6. Conservación y control</h2>
+    <p>
+      El usuario controla los archivos que importa/exporta. Puede borrar datos de la app desde ajustes de Android.
+    </p>
+
+    <h2>7. Cambios a esta política</h2>
+    <p>
+      Esta política puede actualizarse para reflejar cambios técnicos, legales o de servicios integrados.
+    </p>
+  </main>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -122,7 +122,58 @@ Con esto, flashrom/libusb usan el descriptor otorgado por Android en Java, evita
 
 La app está orientada a trabajar con el ecosistema soportado por flashrom (programadores/chips según build y drivers disponibles), incluyendo flujos SPI/I2C cuando el hardware/driver de flashrom lo soporte.
 
-La detección USB en Java usa la API nativa de Android (`UsbManager`) y permite elegir dispositivo cuando hay más de uno conectado. Además, desde el menú se puede cambiar el valor de programador `-p` para cualquier backend soportado por flashrom.
+La detección USB en Java usa la API nativa de Android (`UsbManager`) y permite elegir dispositivo cuando hay más de uno conectado. Además, desde el menú se puede configurar el valor de programador `-p` con dos modos: lista de soportados y modo manual legacy (texto libre). También existe una caja de comando manual en la UI principal para ejecutar parámetros directos de flashrom y ver resultados en el log.
+
+### Programadores soportados por esta build (logs Meson/flashrom)
+
+- asm106x
+- atavia
+- buspirate_spi
+- ch341a_spi
+- ch347_spi
+- dediprog
+- developerbox_spi
+- digilent_spi
+- dirtyjtag_spi
+- drkaiser
+- dummy
+- ft2232_spi
+- gfxnvidia
+- internal
+- it8212
+- jlink_spi
+- linux_mtd
+- linux_spi
+- parade_lspcon
+- mediatek_i2c_spi
+- mstarddc_spi
+- nicintel
+- nicintel_eeprom
+- nicintel_spi
+- nv_sma_spi
+- ogp_spi
+- pickit2_spi
+- pony_spi
+- raiden_debug_spi
+- realtek_mst_i2c_spi
+- satasii
+- serprog
+- spidriver
+- stlinkv3_spi
+- usbblaster_spi
+
+### Programadores no soportados en la plataforma reportada
+
+- atahpt
+- atapromise
+- ni845x_spi
+- nic3com
+- nicnatsemi
+- nicrealtek
+- rayer_spi
+- satamv
+
+> Nota: la app no bloquea programadores manuales. Si un comando falla, comparte el log para depuración.
 
 Flujo recomendado:
 
@@ -155,15 +206,16 @@ bash ./setup-sdk.sh
 ## 8) Uso básico de la app
 
 1. Conecta el programador USB OTG.
-2. Pulsa **Conectar Programador**, elige dispositivo si aparece el selector, y concede permiso.
-3. Usa:
-   - **Probar Conexión** (`flashrom -p <programador>`)
-   - **Leer EEPROM** (`-r bios.bin`)
-   - **Verificar BIOS** (`-v bios.bin`)
-   - **Escribir EEPROM** (`-w bios.bin`)
-4. Importa/exporta `bios.bin` desde/hacia almacenamiento usando SAF.
+2. Pulsa **Detectar y Conectar Automáticamente**, elige dispositivo si aparece el selector, y concede permiso.
+3. Usa los botones principales:
+   - **Identificar Chip** (`flashrom -p <programador>`)
+   - **Leer (Backup)** (`-r bios.bin`)
+   - **Verificar ROM** (`-v bios.bin`)
+   - **Flashear (bios.bin)** (`-w bios.bin`)
+4. Si necesitas diagnóstico avanzado, usa **Comando flashrom manual** (ej. `--version`, `-L`, `--help`, o parámetros `-p` completos).
+5. Importa/exporta `bios.bin` desde/hacia almacenamiento usando SAF.
 
-El panel de log muestra salida nativa real con prefijo `[native]` y estados de entorno/rutas.
+El panel de log muestra salida nativa real con prefijo `[native]`, comandos solicitados y estados de entorno/rutas.
 
 ---
 
@@ -226,3 +278,11 @@ Para auditoría completa archivo-por-archivo (data vs assets vs jniLibs vs estra
 En la práctica, esto garantiza que el binario siempre busque en el runtime interno con la ruta esperada, no en assets.
 
 ---
+
+
+## 13) Publicación y cumplimiento
+
+- Política pública (link en app): https://flasheepromtool.blogspot.com/
+- Política HTML para revisión/hosting: `POLITICA_PRIVACIDAD.html`
+- Descripción de tienda: `GOOGLE_PLAY_DESCRIPCION.md`
+- Guía de integración manual de binarios: `GUIA_INTEGRACION_BINARIOS.md`

--- a/REPORTE_DEPENDENCIAS_BINARIOS.md
+++ b/REPORTE_DEPENDENCIAS_BINARIOS.md
@@ -2,7 +2,7 @@
 
 Este reporte de `DT_NEEDED` se complementa con:
 
-- `MATRIZ_RUNTIME.mdo` (mapeo archivo por archivo a estrategia runtime)
+- `MATRIZ_RUNTIME.md` (mapeo archivo por archivo a estrategia runtime)
 - `AUDITORIA_ANDROID_RUNTIME.md` (checklist operativo)
 
 ## Resumen de dependencias críticas

--- a/app/src/main/java/com/diamon/curso/MainActivity.java
+++ b/app/src/main/java/com/diamon/curso/MainActivity.java
@@ -22,8 +22,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -57,6 +59,43 @@ public class MainActivity extends AppCompatActivity {
     private static final String ACTION_USB_PERMISSION = "com.diamon.curso.USB_PERMISSION";
     private static final String PREFS = "flashrom_prefs";
     private static final String KEY_PROGRAMMER = "selected_programmer";
+    private static final String[] SUPPORTED_PROGRAMMERS = {
+            "asm106x",
+            "atavia",
+            "buspirate_spi",
+            "ch341a_spi",
+            "ch347_spi",
+            "dediprog",
+            "developerbox_spi",
+            "digilent_spi",
+            "dirtyjtag_spi",
+            "drkaiser",
+            "dummy",
+            "ft2232_spi",
+            "gfxnvidia",
+            "internal",
+            "it8212",
+            "jlink_spi",
+            "linux_mtd",
+            "linux_spi",
+            "parade_lspcon",
+            "mediatek_i2c_spi",
+            "mstarddc_spi",
+            "nicintel",
+            "nicintel_eeprom",
+            "nicintel_spi",
+            "nv_sma_spi",
+            "ogp_spi",
+            "pickit2_spi",
+            "pony_spi",
+            "raiden_debug_spi",
+            "realtek_mst_i2c_spi",
+            "satasii",
+            "serprog",
+            "spidriver",
+            "stlinkv3_spi",
+            "usbblaster_spi"
+    };
 
     private UsbManager usbManager;
     private UsbDeviceConnection currentConnection;
@@ -67,6 +106,8 @@ public class MainActivity extends AppCompatActivity {
     private ScrollView scrollLog;
     private TextView tvStatus, tvLog, tvLoadingText;
     private Button btnConnect, btnProbe, btnVerify, btnRead, btnWrite, btnImport, btnExport;
+    private Button btnRunCustomCommand;
+    private EditText etCustomCommand;
 
     private ExecutorService executor = Executors.newSingleThreadExecutor();
     private String selectedProgrammer = "ch341a_spi";
@@ -141,6 +182,8 @@ public class MainActivity extends AppCompatActivity {
         btnWrite = findViewById(R.id.btnWrite);
         btnImport = findViewById(R.id.btnImport);
         btnExport = findViewById(R.id.btnExport);
+        btnRunCustomCommand = findViewById(R.id.btnRunCustomCommand);
+        etCustomCommand = findViewById(R.id.etCustomCommand);
 
         usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
         selectedProgrammer = getSharedPreferences(PREFS, MODE_PRIVATE).getString(KEY_PROGRAMMER, "ch341a_spi");
@@ -213,6 +256,15 @@ public class MainActivity extends AppCompatActivity {
             intent.addCategory(Intent.CATEGORY_OPENABLE);
             intent.setType("*/*");
             fileOpenLauncher.launch(intent);
+        });
+
+        btnRunCustomCommand.setOnClickListener(v -> {
+            String rawCommand = etCustomCommand.getText() == null ? "" : etCustomCommand.getText().toString().trim();
+            if (rawCommand.isEmpty()) {
+                log("Escribe un comando para ejecutar. Ej: --version o -p ch341a_spi -r bios.bin");
+                return;
+            }
+            executeCustomFlashromCommand(rawCommand);
         });
     }
 
@@ -327,6 +379,8 @@ public class MainActivity extends AppCompatActivity {
         log("¡Permiso otorgado! Token interno de USB: " + currentFd);
         log("Conectado a USB VID:PID " + String.format(Locale.US, "%04x:%04x", device.getVendorId(), device.getProductId())
                 + " | DeviceId: " + device.getDeviceId());
+        log("Detección automática: dispositivo marcado como potencialmente compatible con flashrom en esta versión.");
+        log("No se bloquea ningún programador desde la app. Si hay fallos, comparte el comando y el log para depuración.");
 
         btnProbe.setEnabled(true);
         btnVerify.setEnabled(true);
@@ -348,17 +402,63 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void showProgrammerDialog(Runnable action) {
-        android.widget.EditText input = new android.widget.EditText(this);
+        List<String> options = new ArrayList<>();
+        Collections.addAll(options, SUPPORTED_PROGRAMMERS);
+        options.add("Personalizado...");
+
+        LinearLayout container = new LinearLayout(this);
+        container.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int) (20 * getResources().getDisplayMetrics().density);
+        container.setPadding(padding, padding, padding, 0);
+
+        Spinner spinner = new Spinner(this);
+        android.widget.ArrayAdapter<String> adapter = new android.widget.ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_dropdown_item,
+                options
+        );
+        spinner.setAdapter(adapter);
+
+        EditText input = new EditText(this);
         input.setInputType(InputType.TYPE_CLASS_TEXT);
-        input.setHint("Ej: ch341a_spi, ft2232_spi:type=2232H, serprog:dev=/dev/ttyUSB0");
+        input.setHint("Ej: ft2232_spi:type=2232H o serprog:dev=/dev/ttyUSB0");
         input.setText(selectedProgrammer == null ? "ch341a_spi" : selectedProgrammer);
+        input.setVisibility(View.GONE);
+
+        int currentIndex = options.indexOf(selectedProgrammer);
+        if (currentIndex >= 0) {
+            spinner.setSelection(currentIndex);
+        } else {
+            spinner.setSelection(options.size() - 1);
+            input.setVisibility(View.VISIBLE);
+        }
+
+        spinner.setOnItemSelectedListener(new android.widget.AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(android.widget.AdapterView<?> parent, View view, int position, long id) {
+                boolean custom = position == options.size() - 1;
+                input.setVisibility(custom ? View.VISIBLE : View.GONE);
+            }
+
+            @Override
+            public void onNothingSelected(android.widget.AdapterView<?> parent) {
+                input.setVisibility(View.GONE);
+            }
+        });
+
+        container.addView(spinner);
+        container.addView(input);
 
         new android.app.AlertDialog.Builder(this)
                 .setTitle("Programador flashrom")
-                .setMessage("Ingresa el parámetro de programador para -p (compatible con todos los drivers soportados por flashrom).")
-                .setView(input)
+                .setMessage("Selecciona un programador soportado por esta build de flashrom o usa valor personalizado para depurar.")
+                .setView(container)
                 .setPositiveButton("Guardar", (dialog, which) -> {
-                    String value = input.getText() == null ? "" : input.getText().toString().trim();
+                    String selected = options.get(spinner.getSelectedItemPosition());
+                    String value = selected;
+                    if ("Personalizado...".equals(selected)) {
+                        value = input.getText() == null ? "" : input.getText().toString().trim();
+                    }
                     if (value.isEmpty()) {
                         value = "ch341a_spi";
                     }
@@ -371,6 +471,55 @@ public class MainActivity extends AppCompatActivity {
                 })
                 .setNegativeButton("Cancelar", null)
                 .show();
+    }
+
+    private void showLegacyProgrammerDialog(Runnable action) {
+        EditText input = new EditText(this);
+        input.setInputType(InputType.TYPE_CLASS_TEXT);
+        input.setHint("Ej: ch341a_spi, ft2232_spi:type=2232H, serprog:dev=/dev/ttyUSB0");
+        input.setText(selectedProgrammer == null ? "ch341a_spi" : selectedProgrammer);
+
+        new android.app.AlertDialog.Builder(this)
+                .setTitle("Programador flashrom (modo manual anterior)")
+                .setMessage("Ingresa manualmente el parámetro de programador para -p.")
+                .setView(input)
+                .setPositiveButton("Guardar", (dialog, which) -> {
+                    String value = input.getText() == null ? "" : input.getText().toString().trim();
+                    if (value.isEmpty()) {
+                        value = "ch341a_spi";
+                    }
+                    selectedProgrammer = value;
+                    getSharedPreferences(PREFS, MODE_PRIVATE).edit().putString(KEY_PROGRAMMER, value).apply();
+                    log("Programador flashrom actualizado (manual): " + selectedProgrammer);
+                    if (action != null) {
+                        action.run();
+                    }
+                })
+                .setNegativeButton("Cancelar", null)
+                .show();
+    }
+
+    private void executeCustomFlashromCommand(String rawCommand) {
+        File preferredFlashromBin = new File(getFilesDir(), "usr/sbin/flashrom");
+        if (!preferredFlashromBin.exists()) {
+            log("[WARN] flashrom en files/usr/sbin no encontrado; usando fallback jniLibs.");
+            preferredFlashromBin = new File(getApplicationInfo().nativeLibraryDir, "libflashrom_bin.so");
+        }
+        if (!preferredFlashromBin.exists()) {
+            log("Fallo crítico: Binario 'flashrom' no existe. (" + preferredFlashromBin.getAbsolutePath() + ")");
+            return;
+        }
+        String[] args = rawCommand.split("\\s+");
+        log("Comando manual solicitado: flashrom " + rawCommand);
+        if (currentFd < 0) {
+            log("Ejecutando sin USB conectado: útil para comandos como --version, -L o --help.");
+        }
+        setButtonsEnabled(false);
+        final File flashromBin = preferredFlashromBin;
+        executor.execute(() -> {
+            runFlashromProcess(flashromBin, args);
+            runOnUiThread(() -> setButtonsEnabled(true));
+        });
     }
 
     private void executeFlashromTask(String... args) {
@@ -419,7 +568,11 @@ public class MainActivity extends AppCompatActivity {
 
             // Inyectando entorno para las librerías fake_root
             Map<String, String> env = pb.environment();
-            env.put("ANDROID_USB_FD", String.valueOf(currentFd));
+            if (currentFd >= 0) {
+                env.put("ANDROID_USB_FD", String.valueOf(currentFd));
+            } else {
+                env.remove("ANDROID_USB_FD");
+            }
 
             // Recrear las variables de entorno de PTC que incluyen la ruta PATH necesaria
             // si fuesemos a usar otras libs anidadas
@@ -428,7 +581,7 @@ public class MainActivity extends AppCompatActivity {
             env.put("LD_LIBRARY_PATH", jniLibs + ":" + new File(getFilesDir(), "usr/lib").getAbsolutePath());
             env.put("PATH", jniLibs + (fallbackPath != null ? ":" + fallbackPath : ""));
 
-            log("Entorno flashrom => ANDROID_USB_FD=" + currentFd);
+            log("Entorno flashrom => ANDROID_USB_FD=" + (currentFd >= 0 ? currentFd : "NO DEFINIDO"));
             log("Entorno flashrom => LD_LIBRARY_PATH=" + env.get("LD_LIBRARY_PATH"));
             log("Entorno flashrom => PATH=" + env.get("PATH"));
 
@@ -571,6 +724,8 @@ public class MainActivity extends AppCompatActivity {
         btnConnect.setEnabled(enabled);
         btnImport.setEnabled(enabled);
         btnExport.setEnabled(enabled);
+        btnRunCustomCommand.setEnabled(enabled);
+        etCustomCommand.setEnabled(enabled);
     }
 
     @Override
@@ -588,6 +743,9 @@ public class MainActivity extends AppCompatActivity {
             return true;
         } else if (id == R.id.action_programmer) {
             showProgrammerDialog(null);
+            return true;
+        } else if (id == R.id.action_programmer_manual) {
+            showLegacyProgrammerDialog(null);
             return true;
         } else if (id == R.id.action_clear_logs) {
             tvLog.setText("--- Log ---");
@@ -620,7 +778,8 @@ public class MainActivity extends AppCompatActivity {
                 + "• <a href='https://github.com/pciutils/pciutils'>pciutils</a> (GPL-2.0+)<br/>"
                 + "• <a href='https://developer.intra2net.com/git/libftdi'>libftdi</a> (LGPL-2.1+)<br/>"
                 + "• <a href='https://gitlab.zapb.de/libjaylink/libjaylink'>libjaylink</a> (GPL-2.0+)<br/>"
-                + "• <a href='https://github.com/flashrom/flashrom'>flashrom</a> (GPL-2.0+)";
+                + "• <a href='https://github.com/flashrom/flashrom'>flashrom</a> (GPL-2.0+)<br/>"
+                + "• <a href='https://github.com/mik3y/usb-serial-for-android'>usb-serial-for-android</a> (MIT)";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             aboutText.setText(Html.fromHtml(aboutHtml, Html.FROM_HTML_MODE_LEGACY));
         } else {

--- a/app/src/main/java/com/diamon/curso/PolicyActivity.java
+++ b/app/src/main/java/com/diamon/curso/PolicyActivity.java
@@ -31,7 +31,7 @@ public class PolicyActivity extends AppCompatActivity {
 
         webView.setWebViewClient(new WebViewClient());
         // URL base de PTC
-        webView.loadUrl("https://cpiccompiler.blogspot.com/");
+        webView.loadUrl("https://flasheepromtool.blogspot.com/");
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -143,6 +143,21 @@
                 android:text="Guardar ROM leída" />
         </LinearLayout>
 
+        <EditText
+            android:id="@+id/etCustomCommand"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Comando flashrom manual (ej: --version o -p ch341a_spi -L)"
+            android:inputType="text"
+            android:layout_marginBottom="8dp" />
+
+        <Button
+            android:id="@+id/btnRunCustomCommand"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Ejecutar comando manual"
+            android:layout_marginBottom="12dp" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -9,7 +9,12 @@
 
     <item
         android:id="@+id/action_programmer"
-        android:title="Configurar programador flashrom"
+        android:title="Agregar dispositivo/programador flashrom (lista)"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_programmer_manual"
+        android:title="Configurar programador manual (anterior)"
         app:showAsAction="never" />
 
     <item


### PR DESCRIPTION
### Motivation

- Document runtime capabilities, supported programadores and packaging/integration steps for native binaries. 
- Provide a privacy policy and Google Play description for publication and review. 
- Improve the app UI/UX to let users pick a supported programmer from a list, keep legacy manual entry, and run arbitrary `flashrom` commands (including offline commands like `--version`).

### Description

- Added documentation and metadata files: `POLITICA_PRIVACIDAD.html`, `GOOGLE_PLAY_DESCRIPCION.md`, `GUIA_INTEGRACION_BINARIOS.md`, updated `AUDITORIA_ANDROID_RUNTIME.md`, `MATRIZ_RUNTIME.md`, `REPORTE_DEPENDENCIAS_BINARIOS.md` and expanded `README.md` with supported / unsupported programmer lists.  
- Extended `MainActivity.java` to include a `SUPPORTED_PROGRAMMERS` array, a spinner-based programmer selector dialog, a legacy manual programmer dialog, an `EditText` + `Button` to execute custom `flashrom` commands, and improved USB/FD handling and logging (only set `ANDROID_USB_FD` when a valid FD exists and show clearer env logs).  
- Implemented `executeCustomFlashromCommand` and updated `runFlashromProcess` to inject `LD_LIBRARY_PATH`/`PATH` and to run the `flashrom` binary from `files/usr/sbin` with fallback to `jniLibs` as `libflashrom_bin.so`.  
- Updated UI/layout and menus: added `etCustomCommand` and `btnRunCustomCommand` to `activity_main.xml`, added menu item for legacy manual programmer, and changed policy link in `PolicyActivity.java` to the project's blog URL.

### Testing

- Built the Android debug APK with `./gradlew assembleDebug` and the build completed successfully. 
- No automated unit tests were present for these UI/runtime changes, so verification was limited to the project assemble/build step which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23ff5b69083308f8fef4faf44d3c7)