### PR TITLE
Add robust serprog handshake and PTY round-trip checks; avoid exporting ANDROID_USB_FD for serprog

### DIFF
--- a/app/src/main/java/com/diamon/curso/MainActivity.java
+++ b/app/src/main/java/com/diamon/curso/MainActivity.java
@@ -1003,9 +1003,13 @@ public class MainActivity extends AppCompatActivity {
                 if (ptyBridge != null && ptyBridge.isOpen()) {
                     ptyBridge.purge();
                     log("Buffer purgado — ejecutando test de handshake...");
-                    // Test: enviar SYNCNOP+NOP y verificar respuesta 0x15 0x06 0x06
+                    // Test: validar SYNCNOP, NOP y nombre del programador directo sobre USB
                     String handshakeResult = ptyBridge.testHandshake();
                     log("Handshake: " + handshakeResult);
+                    if (!handshakeResult.startsWith("[OK]")) {
+                        log("[ABORTADO] Handshake serprog falló. No se lanza flashrom para evitar falsos errores.");
+                        return;
+                    }
                     // Segunda purga para descartar residuos del test
                     ptyBridge.purge();
                     // Iniciar forwarding AHORA — después de purge+handshake
@@ -1014,6 +1018,12 @@ public class MainActivity extends AppCompatActivity {
                     // Test round-trip: enviar SYNCNOP a través del PTY slave completo
                     String roundTrip = ptyBridge.testPtyRoundTrip();
                     log("Round-trip PTY: " + roundTrip);
+                    if (!roundTrip.startsWith("[OK]")) {
+                        log("[ABORTADO] Round-trip PTY falló. No se lanza flashrom.");
+                        return;
+                    }
+                    // Purga final para arrancar flashrom con buffers limpios
+                    ptyBridge.purge();
                     log("Lanzando flashrom.");
                 }
                 action.run();
@@ -1152,7 +1162,12 @@ public class MainActivity extends AppCompatActivity {
 
             // Inyectando entorno para las librerías fake_root
             Map<String, String> env = pb.environment();
-            if (currentFd >= 0) {
+            // Serprog usa PTY (/dev/pts/N) y NO debe pasar por libusb directo.
+            // Si exportamos ANDROID_USB_FD aquí, el wrapper de libusb parcheado puede
+            // interferir con el mismo dispositivo USB-Serial y romper la sincronización.
+            if ("serprog".equals(selectedProgrammer)) {
+                env.remove("ANDROID_USB_FD");
+            } else if (currentFd >= 0) {
                 env.put("ANDROID_USB_FD", String.valueOf(currentFd));
             } else {
                 env.remove("ANDROID_USB_FD");
@@ -1165,7 +1180,10 @@ public class MainActivity extends AppCompatActivity {
             env.put("LD_LIBRARY_PATH", jniLibs + ":" + new File(getFilesDir(), "usr/lib").getAbsolutePath());
             env.put("PATH", jniLibs + (fallbackPath != null ? ":" + fallbackPath : ""));
 
-            log("Entorno flashrom => ANDROID_USB_FD=" + (currentFd >= 0 ? currentFd : "NO DEFINIDO"));
+            String fdLogValue = "serprog".equals(selectedProgrammer)
+                    ? "NO DEFINIDO (serprog por PTY)"
+                    : (currentFd >= 0 ? String.valueOf(currentFd) : "NO DEFINIDO");
+            log("Entorno flashrom => ANDROID_USB_FD=" + fdLogValue);
             log("Entorno flashrom => LD_LIBRARY_PATH=" + env.get("LD_LIBRARY_PATH"));
             log("Entorno flashrom => PATH=" + env.get("PATH"));
 

--- a/app/src/main/java/com/diamon/curso/PtyBridge.java
+++ b/app/src/main/java/com/diamon/curso/PtyBridge.java
@@ -254,63 +254,62 @@ public class PtyBridge {
         if (usbPort == null)
             return "[ERROR] Puerto USB no disponible";
         try {
-            // 1. Enviar SYNCNOP (0x10) + NOP (0x00) como un solo paquete
-            byte[] testCmd = { 0x10, 0x00 };
-            usbPort.write(testCmd, 2, USB_TIMEOUT_MS);
-            Log.i(TAG, "Handshake test: enviado [0x10, 0x00]");
+            // 1) SYNCNOP (0x10) -> esperado: 15 06
+            usbPort.write(new byte[] { 0x10 }, 1, USB_TIMEOUT_MS);
+            byte[] syncResp = readUsbResponse(2, 5);
+            Log.i(TAG, "Handshake test SYNCNOP: [" + bytesToHex(syncResp, syncResp.length) + "]");
 
-            // 2. Esperar respuesta del Arduino (NAK+ACK del SYNCNOP, ACK del NOP)
-            Thread.sleep(200); // dar tiempo al Arduino para procesar ambos comandos
-            byte[] readBuf = new byte[64];
-            java.io.ByteArrayOutputStream responseStream = new java.io.ByteArrayOutputStream();
+            // 2) NOP (0x00) -> esperado: 06
+            usbPort.write(new byte[] { 0x00 }, 1, USB_TIMEOUT_MS);
+            byte[] nopResp = readUsbResponse(1, 3);
+            Log.i(TAG, "Handshake test NOP: [" + bytesToHex(nopResp, nopResp.length) + "]");
 
-            // Leer con reintentos para capturar toda la respuesta
-            for (int attempt = 0; attempt < 3 && responseStream.size() < 3; attempt++) {
-                int n = usbPort.read(readBuf, USB_TIMEOUT_MS);
-                if (n > 0)
-                    responseStream.write(readBuf, 0, n);
-                if (responseStream.size() < 3)
-                    Thread.sleep(50);
+            // 3) Query Programmer Name (0x03) -> esperado: 06 + 16 bytes
+            usbPort.write(new byte[] { 0x03 }, 1, USB_TIMEOUT_MS);
+            byte[] nameResp = readUsbResponse(17, 6);
+            Log.i(TAG, "Handshake test NAME: [" + bytesToHex(nameResp, nameResp.length) + "]");
+
+            boolean syncOk = syncResp.length >= 2
+                    && (syncResp[0] & 0xFF) == 0x15
+                    && (syncResp[1] & 0xFF) == 0x06;
+            boolean nopOk = nopResp.length >= 1
+                    && (nopResp[0] & 0xFF) == 0x06;
+            boolean nameOk = nameResp.length >= 17
+                    && (nameResp[0] & 0xFF) == 0x06;
+
+            if (!syncOk || !nopOk || !nameOk) {
+                return "[FALLO] Handshake incompleto: SYNC=" + bytesToHex(syncResp, syncResp.length)
+                        + " NOP=" + bytesToHex(nopResp, nopResp.length)
+                        + " NAME=" + bytesToHex(nameResp, nameResp.length);
             }
 
-            byte[] response = responseStream.toByteArray();
-            int totalRead = response.length;
+            byte[] nameBytes = new byte[16];
+            System.arraycopy(nameResp, 1, nameBytes, 0, 16);
+            String progName = new String(nameBytes).trim();
+            return "[OK] Handshake completo: SYNC=" + bytesToHex(syncResp, syncResp.length)
+                    + " NOP=" + bytesToHex(nopResp, nopResp.length)
+                    + " NAME='" + progName + "'";
 
-            // 3. Analizar la respuesta
-            String hexReceived = (totalRead > 0) ? bytesToHex(response, totalRead) : "(vacío)";
-            Log.i(TAG, "Handshake test: recibido [" + hexReceived + "] (" + totalRead + " bytes)");
-
-            if (totalRead == 0) {
-                return "[FALLO] Arduino no respondió nada — ¿firmware cargado? ¿baud rate correcto?";
-            }
-
-            // Respuesta esperada: 0x15 (NAK) 0x06 (ACK) 0x06 (ACK)
-            boolean syncOk = totalRead >= 3
-                    && (response[0] & 0xFF) == 0x15
-                    && (response[1] & 0xFF) == 0x06
-                    && (response[2] & 0xFF) == 0x06;
-
-            if (syncOk) {
-                return "[OK] Handshake perfecto: " + hexReceived
-                        + " (SYNCNOP=NAK+ACK, NOP=ACK) — flashrom debería sincronizar";
-            } else {
-                // Diagnóstico detallado del fallo
-                StringBuilder diag = new StringBuilder();
-                diag.append("[FALLO] Respuesta inesperada: ").append(hexReceived);
-                diag.append(" (esperado: 15 06 06)");
-                if (totalRead >= 1 && (response[0] & 0xFF) == 0x06) {
-                    diag.append("\n  → SYNCNOP solo envía ACK sin NAK previo. " +
-                            "¿Firmware viejo cargado? Verifica case 0x10.");
-                }
-                if (totalRead >= 1 && (response[0] & 0xFF) != 0x15 && (response[0] & 0xFF) != 0x06) {
-                    diag.append("\n  → Byte desconocido (¿basura del bootloader o baud rate incorrecto?)");
-                }
-                return diag.toString();
-            }
         } catch (IOException | InterruptedException e) {
             Log.w(TAG, "Handshake test fallo: " + e.getMessage());
             return "[ERROR] Excepción en test: " + e.getMessage();
         }
+    }
+
+    private byte[] readUsbResponse(int minBytes, int maxAttempts) throws IOException, InterruptedException {
+        byte[] readBuf = new byte[64];
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+
+        for (int attempt = 0; attempt < maxAttempts && out.size() < minBytes; attempt++) {
+            int n = usbPort.read(readBuf, USB_TIMEOUT_MS);
+            if (n > 0) {
+                out.write(readBuf, 0, n);
+            }
+            if (out.size() < minBytes) {
+                Thread.sleep(40);
+            }
+        }
+        return out.toByteArray();
     }
 
     /**
@@ -332,15 +331,19 @@ public class PtyBridge {
         // Hilo A: PTY master → USB (lo que flashrom escribe al puerto serie virtual)
         threadMasterToUsb = new Thread(() -> {
             int totalSent = 0;
+            boolean firstWriteLogged = false;
             try (FileInputStream masterIn = new FileInputStream(masterPfd.getFileDescriptor())) {
                 byte[] buf = new byte[BUFFER_SIZE];
                 while (running && !Thread.currentThread().isInterrupted()) {
                     int n = masterIn.read(buf);
                     if (n > 0 && usbPort != null) {
+                        if (!firstWriteLogged) {
+                            Log.d(TAG, "PTY→USB write " + n + " bytes");
+                            firstWriteLogged = true;
+                        }
                         // Debug: loggear los primeros bytes enviados por flashrom
                         if (totalSent < DEBUG_HEX_LIMIT) {
                             int logLen = Math.min(n, DEBUG_HEX_LIMIT - totalSent);
-                            Log.d(TAG, "PTY→USB write " + n + " bytes");
                             Log.d(TAG, "PTY→USB [" + n + "B]: " + bytesToHex(buf, logLen));
                         }
                         totalSent += n;


### PR DESCRIPTION
### Motivation
- Evitar que `flashrom` se lance sobre un programador Arduino (serprog) cuando la cadena USB↔PTY no está sincronizada, lo que provocaba falsos errores de flasheo. 
- Prevenir interferencias del wrapper de `libusb` al exponer `ANDROID_USB_FD` cuando se usa `serprog` por PTY. 

### Description
- Reworked `PtyBridge.testHandshake()` to perform separate `SYNCNOP`, `NOP` and `Query Programmer Name` transactions, validate responses and return a human-readable diagnostic, and added the helper `readUsbResponse()` for controlled reads. 
- In `MainActivity.ensureProgrammerThenRun()` added purge+handshake+PTY round-trip validation for `serprog`, start forwarding only after successful checks, and abort the operation with logged messages on failure. 
- In `MainActivity.runFlashromProcess()` stopped exporting `ANDROID_USB_FD` to the environment when `selectedProgrammer` equals `serprog`, and improved the environment logging to reflect this exception. 
- Minor runtime logging improvement in `PtyBridge` sender thread to log the first PTY→USB write only once for less spam. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79580fe4c8330a0a4166fe23030f0)