### PR TITLE
Abortar ejecución de flashrom cuando falta el beacon de serprog

### DIFF
--- a/app/src/main/java/com/diamon/curso/MainActivity.java
+++ b/app/src/main/java/com/diamon/curso/MainActivity.java
@@ -1009,7 +1009,10 @@ public class MainActivity extends AppCompatActivity {
                 boolean ready = ptyBridge.prepareForFlashromSession(8000);
                 runOnUiThread(() -> {
                     if (!ready) {
-                        log("[WARN] No se recibió beacon (0xAA 0x55). Continuando con flashrom para diagnóstico.");
+                        log("[ERROR] Arduino no respondió beacon (0xAA 0x55) — abortando ejecución de flashrom.");
+                        ptyBridge.close();
+                        ptyBridge = null;
+                        return;
                     }
                     if (!ptyBridge.isForwardingActive()) {
                         ptyBridge.startForwarding();


### PR DESCRIPTION
### Motivation
- Evitar lanzar `flashrom` en un estado conocido-bueno cuando el puente PTY↔USB no ha sincronizado con el Arduino (falta el beacon 0xAA 0x55). 

### Description
- Cambiado `ensureProgrammerThenRun` en `app/src/main/java/com/diamon/curso/MainActivity.java` para comprobar el resultado de `ptyBridge.prepareForFlashromSession(8000)` antes de lanzar `flashrom`. 
- Si la preparación falla, ahora se registra un error con `log("[ERROR] ...")`, se cierra `ptyBridge` con `ptyBridge.close()` y se asigna `ptyBridge = null`, y se retorna sin ejecutar `flashrom`. 
- El flujo normal mantiene el `startForwarding()`, `purge()` y la ejecución de `flashrom` solo si el beacon fue recibido.

### Testing
- Ejecutado `./gradlew --no-daemon assembleDebug` inicialmente y falló por falta de SDK/`local.properties` (esperado). 
- Ejecutado `bash setup-sdk.sh` para instalar SDK/NDK y generar `local.properties`, y la script completó correctamente. 
- Ejecutado `./gradlew --no-daemon assembleDebug` tras la configuración y la compilación fue `BUILD SUCCESSFUL` (validación de compilación exitosa).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a985d3bfd88330812aebfb51d8eaf5)