### PR TITLE
Add serprog Arduino firmware, PC test plan, compile script and PtyBridge sync fixes

### DIFF
--- a/PLAN_PRUEBAS_PC_SERPROG.md
+++ b/PLAN_PRUEBAS_PC_SERPROG.md
@@ -1,0 +1,175 @@
+# Plan de pruebas en PC para validar serprog (Android + Arduino UNO CH340G)
+
+Este plan permite aislar fallos entre:
+- firmware Arduino (`serprog_arduino_uno_ch340g.ino`),
+- puente Android PTY↔USB (`PtyBridge`),
+- y comportamiento de `flashrom`.
+
+---
+
+## 1) Objetivo
+
+Validar extremo a extremo que:
+1. El Arduino responde correctamente al protocolo serprog base.
+2. `flashrom` sincroniza (`SYNCNOP`) sin duplicaciones/corrupción.
+3. Si **no hay chip SPI conectado**, se obtiene el mensaje esperado: `No EEPROM/flash device found`.
+4. Con chip conectado, la detección/lectura funciona con logs trazables.
+
+---
+
+## 2) Requisitos (PC)
+
+- Linux con `adb`, `flashrom`, `python3`, `screen` o `minicom`.
+- Android SDK platform-tools instalado.
+- Dispositivo Android físico con tu app instalada (debug/release).
+- Arduino UNO CH340G conectado por USB al Android (OTG) o según tu topología de pruebas.
+- Firmware cargado en el Arduino:
+  - `serprog_arduino_uno_ch340g.ino`
+
+Opcional:
+- Analizador lógico USB/UART si quieres diagnóstico de bajo nivel.
+
+---
+
+## 3) Preparación
+
+### 3.1 Compilar firmware en PC
+
+```bash
+./compile-serprog-firmware.sh
+```
+
+### 3.2 Flashear firmware al Arduino (ejemplo)
+
+> Ajusta puerto y programador según tu entorno.
+
+```bash
+arduino --upload --board arduino:avr:uno --port /dev/ttyUSB0 ./serprog_arduino_uno_ch340g.ino
+```
+
+### 3.3 Verificar que Android ve el dispositivo
+
+```bash
+adb devices
+adb shell dumpsys usb
+```
+
+---
+
+## 4) Prueba A: Smoke local en PC (sin Android)
+
+Objetivo: confirmar que el firmware responde en serie como esperas.
+
+1. Abre monitor serie a 115200 8N1 sin control de flujo.
+2. Espera beacon de arranque `AA 55`.
+3. Envía comandos básicos y valida respuesta:
+   - `0x00 -> 06`
+   - `0x01 -> 06 01 00`
+   - `0x10 -> 15 06`
+   - `0x02 -> 06 + 32 bytes`
+
+Ejemplo con Python (adaptar puerto):
+
+```python
+import serial, time
+ser = serial.Serial('/dev/ttyUSB0', 115200, timeout=1)
+time.sleep(2.5)
+print('beacon', ser.read(2).hex())
+for payload, n in [(b'\x00',1),(b'\x01',3),(b'\x10',2),(b'\x02',33)]:
+    ser.write(payload)
+    print(payload.hex(), ser.read(n).hex())
+ser.close()
+```
+
+Criterio de éxito:
+- Respuestas exactas y estables en repeticiones consecutivas.
+
+---
+
+## 5) Prueba B: Android + app + logs PTY/USB
+
+Objetivo: confirmar que el bridge no introduce duplicados al inicio.
+
+1. En la app, selecciona programador `serprog`.
+2. Activa logs detallados del bridge en UI.
+3. Ejecuta operación de prueba (`Probe` / lectura corta).
+4. Captura logs Android:
+
+```bash
+adb logcat -v time | grep -E "PtyBridge|flashrom|USB→PTY|PTY→USB|SYNC"
+```
+
+Criterios de éxito:
+- Secuencia inicial coherente:
+  - `[PTY→USB] ... 10` seguido por `USB→PTY ... 15 06`
+- No ráfagas duplicadas inesperadas de ACK/NAK.
+
+---
+
+## 6) Prueba C: flashrom en Android SIN chip SPI conectado
+
+Objetivo: validar mensaje esperado de no detección.
+
+Desde la app (o comando equivalente), lanzar `flashrom -V -p serprog:dev=...`.
+
+Criterio de éxito:
+- Inicialización serprog completa (sync, iface, cmdmap, bustype)
+- Resultado final:
+  - `No EEPROM/flash device found.`
+
+Esto **no es fallo** del bridge ni del firmware si no hay chip.
+
+---
+
+## 7) Prueba D: flashrom en Android CON chip SPI conectado
+
+1. Conecta chip compatible y cableado SPI correcto (MISO/MOSI/SCK/CS/GND/VCC).
+2. Ejecuta:
+   - Detección: `flashrom -V -p serprog:dev=...`
+   - Lectura: `flashrom -V -p serprog:dev=... -r dump.bin`
+3. Repite 3 veces para descartar intermitencia.
+
+Criterio de éxito:
+- Chip identificado consistentemente.
+- Lectura completa sin errores de sync/timeouts.
+
+---
+
+## 8) Matriz de diagnóstico rápido
+
+- **Falla en Prueba A**: problema en firmware/cableado UART.
+- **A pasa, B falla**: problema en bridge Android PTY↔USB o timing CH340.
+- **B pasa, C da “No EEPROM/flash device found”**: esperado si no hay chip.
+- **B/C pasan, D falla**: problema en cableado SPI, nivel lógico o chip objetivo.
+
+---
+
+## 9) Checklist de evidencia para cerrar incidencia
+
+Guardar:
+- Logcat completo de una corrida buena y una mala.
+- Comando exacto de flashrom usado en cada corrida.
+- Hex de primeras transacciones PTY→USB y USB→PTY.
+- Versión de firmware Arduino (hash/fecha).
+- Foto o esquema de cableado SPI.
+
+---
+
+## 10) Comandos recomendados de captura
+
+```bash
+# Logcat filtrado del bridge
+adb logcat -c
+adb logcat -v threadtime | tee /tmp/serprog_android.log
+
+# Guardar salida flashrom en archivo (si lo ejecutas desde shell Android)
+adb shell 'flashrom -V -p serprog:dev=/dev/pts/XX:115200 2>&1' | tee /tmp/flashrom_run.log
+```
+
+---
+
+## 11) Notas prácticas
+
+- CH340G es sensible a timing tras auto-reset; espera beacon antes de iniciar forwarding.
+- Evita abrir/cerrar puerto serie repetidamente durante una misma prueba.
+- Si hay duplicación de bytes al inicio, comparar siempre PTY→USB vs USB→PTY para ver dónde nace.

--- a/app/src/main/java/com/diamon/curso/MainActivity.java
+++ b/app/src/main/java/com/diamon/curso/MainActivity.java
@@ -1014,11 +1014,11 @@ public class MainActivity extends AppCompatActivity {
                         ptyBridge = null;
                         return;
                     }
+                    ptyBridge.purge();
                     if (!ptyBridge.isForwardingActive()) {
                         ptyBridge.startForwarding();
                         log("Hilos de forwarding activos.");
                     }
-                    ptyBridge.purge();
                     log("Puente PTY↔USB listo — lanzando flashrom.");
                     action.run();
                 });

--- a/app/src/main/java/com/diamon/curso/PtyBridge.java
+++ b/app/src/main/java/com/diamon/curso/PtyBridge.java
@@ -39,6 +39,8 @@ public class PtyBridge {
     private static final int BEACON_BYTE_2 = 0x55;
     /** Cuántos bytes iniciales loggear en hex para diagnóstico */
     private static final int DEBUG_HEX_LIMIT = 32;
+    /** Serializa los primeros bytes PTY→USB para evitar solapamiento de comandos en CH340. */
+    private static final int SERPROG_PREAMBLE_GUARD_BYTES = 48;
 
     /** Callback para enviar logs al UI de la app (no sólo logcat) */
     public interface LogCallback {
@@ -320,6 +322,12 @@ public class PtyBridge {
      * el ACK real del Arduino y no restos del bootloader o ruido del CH340.
      */
     public void purge() {
+        // Evitar carreras con los hilos de forwarding: drenar aquí mientras Thread A/B
+        // están activos puede duplicar/perder bytes y romper SYNC de serprog.
+        if (running) {
+            bridgeLog("Purge omitido: forwarding activo (evita carrera USB↔PTY)");
+            return;
+        }
         // Drenar buffer USB con reintentos (el bootloader puede seguir enviando)
         if (usbPort != null) {
             byte[] drain = new byte[BUFFER_SIZE];
@@ -477,12 +485,34 @@ public class PtyBridge {
                         // Debug: loggear los primeros bytes enviados por flashrom
                         if (totalSent < DEBUG_HEX_LIMIT) {
                             int logLen = Math.min(n, DEBUG_HEX_LIMIT - totalSent);
-                            Log.d(TAG, "PTY→USB [" + n + "B]: " + bytesToHex(buf, logLen));
+                            String debugMsg = "[PTY→USB] " + n + " B: " + bytesToHex(buf, logLen);
+                            Log.d(TAG, debugMsg);
+                            bridgeLog(debugMsg);
                         }
                         totalSent += n;
                         try {
-                            usbPort.write(buf, n, USB_TIMEOUT_MS);
-                            diagUsbBytesWritten += n;
+                            int preGuardRemaining = Math.max(0, SERPROG_PREAMBLE_GUARD_BYTES - (totalSent - n));
+                            if (preGuardRemaining > 0) {
+                                int guarded = Math.min(preGuardRemaining, n);
+                                for (int i = 0; i < guarded; i++) {
+                                    byte[] one = new byte[] { buf[i] };
+                                    usbPort.write(one, 1, USB_TIMEOUT_MS);
+                                    diagUsbBytesWritten += 1;
+                                    // CH340 + firmware serprog con limpieza agresiva en SYNCNOP:
+                                    // separar bytes iniciales reduce riesgo de que un comando siguiente
+                                    // llegue en el mismo burst y sea descartado por el firmware.
+                                    sleepQuietly(2);
+                                }
+                                if (n > guarded) {
+                                    byte[] tail = new byte[n - guarded];
+                                    System.arraycopy(buf, guarded, tail, 0, n - guarded);
+                                    usbPort.write(tail, tail.length, USB_TIMEOUT_MS);
+                                    diagUsbBytesWritten += tail.length;
+                                }
+                            } else {
+                                usbPort.write(buf, n, USB_TIMEOUT_MS);
+                                diagUsbBytesWritten += n;
+                            }
                         } catch (IOException e) {
                             diagUsbWriteErrors++;
                             if (running) {

--- a/compile-serprog-firmware.sh
+++ b/compile-serprog-firmware.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKETCH_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/serprog_arduino_uno_ch340g.ino"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+SKETCH_DIR="${WORK_DIR}/serprog_sketch"
+mkdir -p "${SKETCH_DIR}"
+cp "${SKETCH_SRC}" "${SKETCH_DIR}/serprog_sketch.ino"
+
+echo "Compilando firmware serprog (Arduino UNO)..."
+arduino --verify --board arduino:avr:uno "${SKETCH_DIR}/serprog_sketch.ino"
+
+echo "OK: compilación completada"

--- a/serprog_arduino_uno_ch340g.ino
+++ b/serprog_arduino_uno_ch340g.ino
@@ -1,0 +1,220 @@
+#include <SPI.h>
+
+// serprog status bytes
+#define S_ACK 0x06
+#define S_NAK 0x15
+
+// Beacon consumido por PtyBridge antes de habilitar forwarding
+#define BEACON_BYTE1 0xAA
+#define BEACON_BYTE2 0x55
+
+// Chip-select SPI (Arduino UNO)
+#define SPI_CS_PIN 10
+
+// Comando opcional de diagnóstico: vuelca los últimos comandos recibidos
+#define CMD_DEBUG_DUMP 0xEE
+#define DEBUG_BUF_SIZE 32
+
+byte debugCmdBuffer[DEBUG_BUF_SIZE];
+uint8_t debugCmdIndex = 0;
+
+void handle_spi_op();
+uint32_t read_fixed_size(int n);
+void flush_serial_input();
+
+void setup() {
+  Serial.begin(115200);
+  Serial.setTimeout(100);
+
+  for (int i = 0; i < DEBUG_BUF_SIZE; i++) {
+    debugCmdBuffer[i] = 0xFF;
+  }
+
+  // CH340/UNO suele reiniciar al abrir puerto: esperar estabilidad
+  delay(2000);
+  flush_serial_input();
+
+  // Beacon de arranque para el host Android (PtyBridge)
+  Serial.write(BEACON_BYTE1);
+  Serial.write(BEACON_BYTE2);
+  Serial.flush();
+
+  delay(100);
+  flush_serial_input();
+
+  SPI.begin();
+  SPI.setClockDivider(SPI_CLOCK_DIV4); // ~4MHz en UNO
+  SPI.setDataMode(SPI_MODE0);
+  SPI.setBitOrder(MSBFIRST);
+
+  pinMode(SPI_CS_PIN, OUTPUT);
+  digitalWrite(SPI_CS_PIN, HIGH);
+
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+}
+
+void loop() {
+  if (Serial.available() <= 0) {
+    return;
+  }
+
+  digitalWrite(LED_BUILTIN, HIGH);
+  byte cmd = (byte)Serial.read();
+
+  debugCmdBuffer[debugCmdIndex] = cmd;
+  debugCmdIndex = (debugCmdIndex + 1) % DEBUG_BUF_SIZE;
+
+  switch (cmd) {
+    case 0x00: // NOP
+      Serial.write(S_ACK);
+      Serial.flush();
+      break;
+
+    case 0x01: // Query Interface Version v1.0
+      Serial.write(S_ACK);
+      Serial.write(0x01);
+      Serial.write(0x00);
+      Serial.flush();
+      break;
+
+    case 0x02: { // Query Command Map (32 bytes)
+      byte map[32] = {0};
+      map[0] = 0x3F; // 0x00..0x05
+      map[2] = 0x0D; // 0x10, 0x12 y 0x13
+
+      Serial.write(S_ACK);
+      Serial.write(map, 32);
+      Serial.flush();
+      break;
+    }
+
+    case 0x03: { // Query Programmer Name (16 bytes)
+      static const char name[16] = "arduino";
+      Serial.write(S_ACK);
+      Serial.write((const uint8_t*)name, 16);
+      Serial.flush();
+      break;
+    }
+
+    case 0x04: // Query Serial Buffer Size
+      Serial.write(S_ACK);
+      Serial.write(0x00); // LE -> 0x0100
+      Serial.write(0x01);
+      Serial.flush();
+      break;
+
+    case 0x05: // Query Supported Bustypes
+      Serial.write(S_ACK);
+      Serial.write(0x08); // SPI
+      Serial.flush();
+      break;
+
+    case 0x10: // SYNCNOP: NAK + ACK
+      // Limpia basura vieja antes de responder SYNC
+      flush_serial_input();
+      Serial.write(S_NAK);
+      Serial.write(S_ACK);
+      Serial.flush();
+      break;
+
+    case 0x12: { // Set bus type
+      byte bt = (byte)read_fixed_size(1);
+      if (bt == 0x08) {
+        Serial.write(S_ACK); // SPI soportado
+      } else {
+        Serial.write(S_NAK);
+      }
+      Serial.flush();
+      break;
+    }
+
+    case 0x13: // SPI operation
+      handle_spi_op();
+      break;
+
+    case CMD_DEBUG_DUMP: {
+      // Formato: DD + 32 bytes + CC
+      Serial.write(0xDD);
+      Serial.write(debugCmdBuffer, DEBUG_BUF_SIZE);
+      Serial.write(0xCC);
+      Serial.flush();
+      break;
+    }
+
+    default:
+      Serial.write(S_NAK);
+      Serial.flush();
+      // Evitar que bytes residuales queden desfasando el parser
+      flush_serial_input();
+      break;
+  }
+
+  digitalWrite(LED_BUILTIN, LOW);
+}
+
+void handle_spi_op() {
+  uint32_t slen = read_fixed_size(3);
+  uint32_t rlen = read_fixed_size(3);
+
+  if (slen == 0xFFFFFFFF || rlen == 0xFFFFFFFF) {
+    Serial.write(S_NAK);
+    Serial.flush();
+    flush_serial_input();
+    return;
+  }
+
+  Serial.write(S_ACK);
+  Serial.flush();
+
+  digitalWrite(SPI_CS_PIN, LOW);
+
+  while (slen--) {
+    unsigned long start = millis();
+    while (Serial.available() == 0) {
+      if (millis() - start > 1000) {
+        digitalWrite(SPI_CS_PIN, HIGH);
+        Serial.write(S_NAK);
+        Serial.flush();
+        return;
+      }
+    }
+    SPI.transfer((uint8_t)Serial.read());
+  }
+
+  if (rlen > 0) {
+    byte buffer[64];
+    while (rlen > 0) {
+      uint32_t chunk = (rlen > sizeof(buffer)) ? sizeof(buffer) : rlen;
+      for (uint32_t i = 0; i < chunk; i++) {
+        buffer[i] = SPI.transfer(0x00);
+      }
+      Serial.write(buffer, chunk);
+      Serial.flush();
+      rlen -= chunk;
+    }
+  }
+
+  digitalWrite(SPI_CS_PIN, HIGH);
+}
+
+uint32_t read_fixed_size(int n) {
+  uint32_t val = 0;
+  for (int i = 0; i < n; i++) {
+    unsigned long start = millis();
+    while (Serial.available() == 0) {
+      if (millis() - start > 1000) {
+        return 0xFFFFFFFF;
+      }
+    }
+    val |= ((uint32_t)(uint8_t)Serial.read()) << (i * 8);
+  }
+  return val;
+}
+
+void flush_serial_input() {
+  delay(10);
+  while (Serial.available() > 0) {
+    (void)Serial.read();
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a complete end-to-end serprog environment (Arduino firmware + PC test plan) and fix timing/race issues in the PTY↔USB bridge to avoid duplicated/corrupted SYNC during `flashrom` sessions. 

### Description

- Add `serprog_arduino_uno_ch340g.ino` implementing the serprog protocol, beacon (`0xAA 0x55`), `SYNCNOP` handling, SPI operations, and a debug dump command. 
- Add `PLAN_PRUEBAS_PC_SERPROG.md` with a PC test plan to validate Arduino firmware, Android PTY↔USB bridge, and `flashrom` scenarios. 
- Add `compile-serprog-firmware.sh` to compile the Arduino sketch via the Arduino CLI. 
- Change `MainActivity` to call `ptyBridge.purge()` before enabling forwarding so the bridge drains boot noise prior to starting forwarders. 
- Update `PtyBridge` to avoid purging while forwarding is active and to serialize the first `SERPROG_PREAMBLE_GUARD_BYTES` bytes from `PTY→USB` with small delays to prevent CH340/firmware burst coalescing that could break `SYNC`/`SYNCNOP` handling. 

### Testing

- Compiled the Arduino firmware using `./compile-serprog-firmware.sh` which completed successfully. 
- Built the Android app with `./gradlew assembleDebug` which compiled the modified Java sources successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99d19c67c8330b20ef4071ce63f19)